### PR TITLE
Button; handle options.onclick after the internal listeners

### DIFF
--- a/mint/Button.hx
+++ b/mint/Button.hx
@@ -52,9 +52,9 @@ class Button extends Control {
             internal_visible: options.visible
         });
 
-        if(options.onclick != null) onmouseup.listen(options.onclick);
-
         renderer = rendering.get( Button, this );
+
+        if(options.onclick != null) onmouseup.listen(options.onclick);
 
         oncreate.emit();
 


### PR DESCRIPTION
My case: I click a button to change the state in a state machine, when I click it gives me a 'Null object' error. If the ``options.onclick`` function is handled first, it may throw an that error when running [this line](https://github.com/snowkit/mint/blob/master/mint/render/luxe/Button.hx#L61). Changing the order of the ``listen`` functions there is no 'Null object' when running the mentioned line.