### PR TITLE
Signal; Guard against null when emitting

### DIFF
--- a/mint/core/Signal.hx
+++ b/mint/core/Signal.hx
@@ -50,17 +50,21 @@ class Signal<T> {
             var _idx = 0;
             var _count = $ethis.listeners.length;
             while(_idx < _count) {
-                var fn = $ethis.listeners[_idx];
-                if(fn != null) {
-                    fn($a{args});
+                if($ethis != null) {
+                    var fn = $ethis.listeners[_idx];
+                    if(fn != null) {
+                        fn($a{args});
+                    }
                 }
                 _idx++;
             }
 
-            while(_count > 0) {
-                var fn = $ethis.listeners[_count-1];
-                if(fn == null) $ethis.listeners.splice(_count-1, 1);
-                _count--;
+            if($ethis != null) {
+                while(_count > 0) {
+                    var fn = $ethis.listeners[_count-1];
+                    if(fn == null) $ethis.listeners.splice(_count-1, 1);
+                    _count--;
+                }
             }
         }
     } //emit


### PR DESCRIPTION
This PR solves the particular case where the canvas is destroyed as a direct result of an emitted event but there are still more emitted events that needs to be resolved.

Concretely, I'm doing something like the following:
```haxe
new mint.Button({
    // ...
    onclick: function(e,c) { canvas.destroy(); },
});
```
Here, the canvas is destroyed "on mouse down" but "on mouse up" is still queued to be emitted. This causes an exception in Signal because `$ethis` is `null`. 